### PR TITLE
Update docker base image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,8 +13,8 @@ jobs:
         include:
         - name: '1.13.1_cu117'
           base_image: mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
-        - name: '2.0.1_cu118'
-          base_image: mosaicml/pytorch:2.0.1_cu118-python3.10-ubuntu20.04
+        - name: '2.1.1_cu121'
+          base_image: mosaicml/pytorch:2.1.2_cu121-python3.10-ubuntu20.04
 
     steps:
     - name: Maximize Build Space on Worker


### PR DESCRIPTION
Updating the base image to use the newer Mistral models. 

Issue : We cannot use Mistral Instruct v0.2 with the current base image and downloaded packages. 
Solution : Updating to newer image. 